### PR TITLE
Update release-please token to bypass GitHub Actions restrictions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,14 +22,11 @@ jobs:
       - name: Release Please
         uses: google-github-actions/release-please-action@v4
         with:
-          # For general repos (no language-specific version files), use "simple".
           release-type: simple
-          # Set to true to create GitHub Releases and tags when the PR is merged.
           create-release: true
-          # Customize if your default branch is "main" or "master".
           target-branch: ${{ github.ref_name }}
-          # Optional: Change to your repo name/owner if needed in forks
-          # token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT to bypass org policy that blocks GITHUB_TOKEN from creating PRs
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   # Optional: publish a GitHub Release when tags are pushed (redundant if create-release=true above).
   gh-release:


### PR DESCRIPTION
This pull request updates the `release-please` GitHub Action workflow to use a Personal Access Token (PAT) instead of the default `GITHUB_TOKEN`. This change is necessary because the `GITHUB_TOKEN` is not permitted to create or approve pull requests due to organizational policies. By using `secrets.RELEASE_PLEASE_TOKEN`, we ensure that the release process can proceed without issue.

---

> This pull request was co-created with Cosine Genie

Original Task: [awesome-devops-projects/15s2z43xym6e](https://cosine.sh/o8vpx2u4tpxf/awesome-devops-projects/task/15s2z43xym6e)
Author: Raja Muhammad Awais
